### PR TITLE
Add dev dep esbuild

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ## Install
 
 ```bash
-npm i -D cypress @bahmutov/cypress-esbuild-preprocessor
+npm i -D cypress @bahmutov/cypress-esbuild-preprocessor esbuild
 # note: this plugin assumes the esbuild is peer dependency
 ```
 


### PR DESCRIPTION
Need to fix :
```
The function exported by the plugins file threw an error.
We invoked the function exported by `****/cypress/plugins/index.js`, but it threw an error.
 Error: Cannot find module 'esbuild'
```