### PR TITLE
Support esbuild user options in run mode

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,10 +4,11 @@ const debug = require('debug')('cypress-esbuild-preprocessor')
 // bundled[filename] => promise
 const bundled = {}
 
-const bundleOnce = ({ filePath, outputPath }) => {
+const bundleOnce = ({ filePath, outputPath, esBuildUserOptions }) => {
   const started = +new Date()
 
   esbuild.buildSync({
+    ...esBuildUserOptions,
     entryPoints: [filePath],
     outfile: outputPath,
     bundle: true,
@@ -26,7 +27,7 @@ const createBundler = (esBuildUserOptions = {}) => {
     debug({ filePath, outputPath, shouldWatch })
 
     if (!shouldWatch) {
-      bundleOnce({ filePath, outputPath })
+      bundleOnce({ filePath, outputPath, esBuildUserOptions })
       return outputPath
     }
 


### PR DESCRIPTION
`bundleOnce` does not pass user supplied options to esbuild. As a result, `cypress open` and `cypress run` can have behavior discrepancy.