### PR TITLE
Avoid using buildSync

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -8,15 +8,18 @@ const bundleOnce = ({ filePath, outputPath, esBuildUserOptions }) => {
   debug('bundleOnce %s', filePath)
   const started = +new Date()
 
-  esbuild.buildSync({
-    ...esBuildUserOptions,
-    entryPoints: [filePath],
-    outfile: outputPath,
-    bundle: true,
-  })
-  const finished = +new Date()
-  const elapsed = finished - started
-  debug('bundling %s took %dms', filePath, elapsed)
+  return esbuild
+    .build({
+      ...esBuildUserOptions,
+      entryPoints: [filePath],
+      outfile: outputPath,
+      bundle: true,
+    })
+    .then(() => {
+      const finished = +new Date()
+      const elapsed = finished - started
+      debug('bundling %s took %dms', filePath, elapsed)
+    })
 }
 
 const createBundler = (esBuildUserOptions = {}) => {
@@ -28,8 +31,9 @@ const createBundler = (esBuildUserOptions = {}) => {
     debug({ filePath, outputPath, shouldWatch })
 
     if (!shouldWatch) {
-      bundleOnce({ filePath, outputPath, esBuildUserOptions })
-      return outputPath
+      return bundleOnce({ filePath, outputPath, esBuildUserOptions }).then(
+        () => outputPath,
+      )
     }
 
     if (bundled[filePath]) {


### PR DESCRIPTION
This allows anyone to use plugins even in Cypress run-mode.

Esbuild will otherwise throw a `Cannot use plugins in synchronous API calls`.

Specifically, we use a plugin to process feature-files, as shown below.

```js
const FeatureOnLoadPlugin = {
  name: "feature",
  setup(build) {
    const fs = require("fs");

    build.onLoad({ filter: /\.feature$/ }, async args => {
      const content = await fs.promises.readFile(args.path, "utf8");

      return {
        contents: await compile(content, args.path),
        loader: "js"
      };
    });
  }
};

on(
  "file:preprocessor",
  createBundler({
    plugins: [FeatureOnLoadPlugin]
  })
);
```