### PR TITLE
fix: Add typescript definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0-development",
   "description": "Bundle Cypress specs using esbuild",
   "main": "src",
+  "typings": "src/index.d.ts",
   "files": [
     "src"
   ],

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,11 +1,6 @@
 /// <reference types="node" />
 import { BuildOptions } from 'esbuild';
 
-export interface BundleOnceParams {
-  filePath: string;
-  outputPath: string;
-  esBuildUserOptions: BuildOptions;
-}
 export interface CypressFileObject {
   filePath: string;
   outputPath: string;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,46 @@
+/// <reference types="node" />
+import { BuildOptions } from 'esbuild';
+
+export interface BundleOnceParams {
+  filePath: string;
+  outputPath: string;
+  esBuildUserOptions: BuildOptions;
+}
+export interface CypressFileObject {
+  filePath: string;
+  outputPath: string;
+  shouldWatch: boolean;
+}
+export declare type CypressPlugin = (file: CypressFileObject & NodeJS.EventEmitter) => Promise<string> | string;
+
+export interface BundleOnceParams {
+  filePath: string;
+  outputPath: string;
+  esBuildUserOptions: BuildOptions;
+}
+
+/**
+ * Bundles the files only once.
+ *
+ * @param {BundleOnceParams} params
+ * @returns {Promise<void>}
+ */
+export declare const bundleOnce: ({ filePath, outputPath, esBuildUserOptions, }: BundleOnceParams) => Promise<void>;
+
+
+/**
+ * Pass ESBuild options to be applied to each spec file
+ *
+ * @example
+ *
+ * const bundler = createBundler({
+ *  define: {
+ *    "process.env.NODE_ENV": '"development"'
+ *  }
+ * });
+ * on('file:preprocessor', bundler)
+ *
+ * @param {BuildOptions} esBuildUserOptions
+ * @returns
+ */
+export declare const createBundler: (esBuildUserOptions?: BuildOptions) => CypressPlugin;

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,21 @@
 const esbuild = require('esbuild')
 const debug = require('debug')('cypress-esbuild-preprocessor')
 
+/**
+ * @typedef {import("./index.d").BundleOnceParams} BundleOnceParams
+ * @typedef {import("./index.d").CypressPlugin} CypressPlugin
+ * @typedef {import("esbuild").BuildOptions} BuildOptions
+ */
+
 // bundled[filename] => promise
 const bundled = {}
 
+/**
+ * Bundles the files only once.
+ *
+ * @param {BundleOnceParams} params
+ * @returns {Promise<void>}
+ */
 const bundleOnce = ({ filePath, outputPath, esBuildUserOptions }) => {
   debug('bundleOnce %s', filePath)
   const started = +new Date()
@@ -22,6 +34,21 @@ const bundleOnce = ({ filePath, outputPath, esBuildUserOptions }) => {
     })
 }
 
+/**
+ * Pass ESBuild options to be applied to each spec file
+ *
+ * @example
+ *
+ * const bundler = createBundler({
+ *  define: {
+ *    "process.env.NODE_ENV": '"development"'
+ *  }
+ * });
+ * on('file:preprocessor', bundler)
+ *
+ * @param {BuildOptions} esBuildUserOptions
+ * @returns {CypressPlugin}
+ */
 const createBundler = (esBuildUserOptions = {}) => {
   debug('ESBuild user options %o', esBuildUserOptions)
 


### PR DESCRIPTION
## Because:
- There was an [issue opened](https://github.com/bahmutov/cypress-esbuild-preprocessor/issues/115) asking for Typescript definitions for this package.

## This commit:
- Adds an `index.d.ts` file to the `src` folder, as well as jsdoc documentation.
- Adds a `typings` entry on the `package.json` file