### PR TITLE
Upgrade Cypress GitHub action to v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Run tests 🧪
-        uses: cypress-io/github-action@v2
+        uses: cypress-io/github-action@v3
         env:
           DEBUG: cypress-esbuild-preprocessor
 


### PR DESCRIPTION
Quick PR to upgrade `cypress-io/github-action` to v3.

## Acceptance criteria
- [ ] CI passes.